### PR TITLE
fix: elytra double slot break

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 
     modCompileOnly "maven.modrinth:ledger:1.3.5"
     modCompileOnly "maven.modrinth:waterframes:FABRIC-mc1.21.1-v2.1.12c"
+    modCompileOnly "maven.modrinth:elytra-slot:9.0.1+1.21.1"
+    modCompileOnly "maven.modrinth:trinkets:3.10.0"
 
     discordMcChatApiJar "maven.modrinth:discord-mc-chat:2.5.0"
     modCompileOnly(configurations.discordMcChatApiJar.collect {

--- a/src/main/java/com/thecolonel63/ccmod/mixin/fixes/ElytraSlotTrinketMixin.java
+++ b/src/main/java/com/thecolonel63/ccmod/mixin/fixes/ElytraSlotTrinketMixin.java
@@ -1,0 +1,30 @@
+package com.thecolonel63.ccmod.mixin.fixes;
+
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.function.Consumer;
+
+@Mixin(targets = "com.illusivesoulworks.elytraslot.ElytraSlotFabricMod$1")
+public class ElytraSlotTrinketMixin {
+    @Redirect(
+            method = "tick(Lnet/minecraft/item/ItemStack;Ldev/emi/trinkets/api/SlotReference;Lnet/minecraft/entity/LivingEntity;)V",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/item/ItemStack;damage(ILnet/minecraft/server/world/ServerWorld;Lnet/minecraft/server/network/ServerPlayerEntity;Ljava/util/function/Consumer;)V"
+            )
+    )
+    private void elytraslot$skipDamageIfOneLeft(
+            ItemStack stack, int amount, ServerWorld serverWorld, ServerPlayerEntity serverPlayerEntity, Consumer<Item> breakCallback
+    ) {
+        int durabilityLeft = stack.getMaxDamage() - stack.getDamage();
+        if (durabilityLeft > 1) {
+            stack.damage(amount, serverWorld, serverPlayerEntity, breakCallback);
+        }
+    }
+}

--- a/src/main/java/com/thecolonel63/ccmod/mixin/fixes/ElytraSlotTrinketMixin.java
+++ b/src/main/java/com/thecolonel63/ccmod/mixin/fixes/ElytraSlotTrinketMixin.java
@@ -1,30 +1,32 @@
 package com.thecolonel63.ccmod.mixin.fixes;
 
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Redirect;
 
 import java.util.function.Consumer;
 
 @Mixin(targets = "com.illusivesoulworks.elytraslot.ElytraSlotFabricMod$1")
 public class ElytraSlotTrinketMixin {
-    @Redirect(
+    @WrapOperation(
             method = "tick(Lnet/minecraft/item/ItemStack;Ldev/emi/trinkets/api/SlotReference;Lnet/minecraft/entity/LivingEntity;)V",
             at = @At(
                     value = "INVOKE",
                     target = "Lnet/minecraft/item/ItemStack;damage(ILnet/minecraft/server/world/ServerWorld;Lnet/minecraft/server/network/ServerPlayerEntity;Ljava/util/function/Consumer;)V"
             )
     )
-    private void elytraslot$skipDamageIfOneLeft(
-            ItemStack stack, int amount, ServerWorld serverWorld, ServerPlayerEntity serverPlayerEntity, Consumer<Item> breakCallback
+    private void ccmod$skipDamageIfOneLeft(
+            ItemStack stack, int amount, ServerWorld serverWorld, ServerPlayerEntity serverPlayerEntity,
+            Consumer<Item> breakCallback, Operation<Void> original
     ) {
         int durabilityLeft = stack.getMaxDamage() - stack.getDamage();
         if (durabilityLeft > 1) {
-            stack.damage(amount, serverWorld, serverPlayerEntity, breakCallback);
+            original.call(stack, amount, serverWorld, serverPlayerEntity, breakCallback);
         }
     }
 }

--- a/src/main/resources/ccmod.mixins.json
+++ b/src/main/resources/ccmod.mixins.json
@@ -23,7 +23,8 @@
     "fixes.FallingBlockEntityMixin",
     "fixes.PistonBlockEntityMixin",
     "fixes.PistonBlockMixin",
-    "fixes.TripwireHookBlockMixin"
+    "fixes.TripwireHookBlockMixin",
+    "fixes.ElytraSlotTrinketMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
```
Renterworks
— 06/09/2025, 23:34
I figured out how to completely break elytra, so if you wear an elytra in the elytra slot, break it and then equip a second one in your chestplate slot and use it, it completely destroys the broken elytra and deletes it

Syfe
— 06/09/2025, 23:34
lmfao

Renterworks
— 06/09/2025, 23:45
i literally figure out a way to break everything
```